### PR TITLE
releases: extract update-release-info.py and reuse artifact in update job

### DIFF
--- a/.github/workflows/debian-releases.yml
+++ b/.github/workflows/debian-releases.yml
@@ -93,15 +93,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install jq
-        run: |
-          if ! which jq; then
-            sudo apt-get update --quiet
-            sudo apt-get install --no-install-recommends --yes jq
-          fi
+      - uses: actions/download-artifact@v6
+        with:
+          name: debian-releases-jsons
 
-      - name: Regenerate and update action.yml
-        run: ./debian-releases/buildinfo.sh --update-action-yml > /dev/null
+      - name: Update action.yml
+        run: |
+          full_json="$(jq -c -M . regen.json)"
+          python3 scripts/update_release_info.py debian-releases/action.yml "${full_json}"
+          npx prettier --write debian-releases/action.yml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/ubuntu-releases.yml
+++ b/.github/workflows/ubuntu-releases.yml
@@ -93,15 +93,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install jq
-        run: |
-          if ! which jq; then
-            sudo apt-get update --quiet
-            sudo apt-get install --no-install-recommends --yes jq
-          fi
+      - uses: actions/download-artifact@v6
+        with:
+          name: ubuntu-releases-jsons
 
-      - name: Regenerate and update action.yml
-        run: ./ubuntu-releases/buildinfo.sh --update-action-yml > /dev/null
+      - name: Update action.yml
+        run: |
+          full_json="$(jq -c -M . regen.json)"
+          python3 scripts/update_release_info.py ubuntu-releases/action.yml "${full_json}"
+          npx prettier --write ubuntu-releases/action.yml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/debian-releases/buildinfo.sh
+++ b/debian-releases/buildinfo.sh
@@ -157,16 +157,7 @@ done
 
 if [ "${update_action_yml}" = true ]; then
   action_yml="${SCRIPT_DIR}/action.yml"
-  python3 -c "
-import re, sys
-
-action = open(sys.argv[1]).read()
-new_json = sys.argv[2]
-pattern = r'(RELEASE_INFO_JSON: >-\n).*?(\n\n      run:)'
-replacement = r'\g<1>          ' + new_json + r'\g<2>'
-result = re.sub(pattern, replacement, action, flags=re.DOTALL)
-open(sys.argv[1], 'w').write(result)
-" "${action_yml}" "${full_json}"
+  python3 "${SCRIPT_DIR}/../scripts/update_release_info.py" "${action_yml}" "${full_json}"
   if command -v prettier > /dev/null 2>&1; then
     prettier --write "${action_yml}" > /dev/null 2>&1
   elif command -v npx > /dev/null 2>&1; then

--- a/scripts/update_release_info.py
+++ b/scripts/update_release_info.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Update the RELEASE_INFO_JSON block in an action.yml file."""
+
+import re
+import sys
+
+
+def main():
+    """Update action.yml with new release info JSON."""
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <action.yml> <json>", file=sys.stderr)
+        sys.exit(1)
+
+    action_yml = sys.argv[1]
+    new_json = sys.argv[2]
+
+    with open(action_yml, encoding="utf-8") as f:
+        action = f.read()
+
+    pattern = r"(RELEASE_INFO_JSON: >-\n).*?(\n\n      run:)"
+    replacement = r"\g<1>          " + new_json + r"\g<2>"
+    result = re.sub(pattern, replacement, action, flags=re.DOTALL)
+
+    with open(action_yml, "w", encoding="utf-8") as f:
+        f.write(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ubuntu-releases/buildinfo.sh
+++ b/ubuntu-releases/buildinfo.sh
@@ -148,16 +148,7 @@ done
 
 if [ "${update_action_yml}" = true ]; then
   action_yml="${SCRIPT_DIR}/action.yml"
-  python3 -c "
-import re, sys
-
-action = open(sys.argv[1]).read()
-new_json = sys.argv[2]
-pattern = r'(RELEASE_INFO_JSON: >-\n).*?(\n\n      run:)'
-replacement = r'\g<1>          ' + new_json + r'\g<2>'
-result = re.sub(pattern, replacement, action, flags=re.DOTALL)
-open(sys.argv[1], 'w').write(result)
-" "${action_yml}" "${full_json}"
+  python3 "${SCRIPT_DIR}/../scripts/update_release_info.py" "${action_yml}" "${full_json}"
   if command -v prettier > /dev/null 2>&1; then
     prettier --write "${action_yml}" > /dev/null 2>&1
   elif command -v npx > /dev/null 2>&1; then


### PR DESCRIPTION
Move the action.yml rewrite logic into scripts/update-release-info.py, used by both buildinfo.sh --update-action-yml and the CI update job.

The update job now downloads the regen.json artifact from the validate job instead of re-running buildinfo.sh. Use a fine-grained PAT for creating pull requests.