### PR TITLE
fix: use consistent for markdown unsorted list style

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,6 +1,6 @@
 # Unordered list style
 MD004:
-  style: dash
+  style: consistent
 
 # Line length
 MD013:


### PR DESCRIPTION
The release-please bot uses asterisk and keeps failing the CI for meaningless error MD004.